### PR TITLE
Fixes the Barcelona / Decidim Barcelona URL

### DIFF
--- a/_projects/barcelona.md
+++ b/_projects/barcelona.md
@@ -20,8 +20,8 @@ screens:
   - projects/screens/BCN-Decidim-5.jpg
   - projects/screens/BCN-Decidim-6.jpg
 screen_1: projects/screens/panama-papers-1.jpg
-public_url: https://panamapapers.icij.org/
-client_url: https://icij.org/
+public_url: https://decidim.barcelona/
+client_url: https://ajuntament.barcelona.cat/
 weight: 3
 ---
 


### PR DESCRIPTION
The link was to the panama papers, it should point to Decidim Barcelona / Barcelona City Hall